### PR TITLE
using appropriate error name

### DIFF
--- a/keycdn/keycdn.py
+++ b/keycdn/keycdn.py
@@ -74,6 +74,6 @@ class Api(object):
         elif method == 'DELETE':
             r = requests.delete(url, auth=(self.__api_key, ''), data=params)
         else:
-            raise ValueError('Only the methods GET, POST, PUT, DELETE are supported.')
+            raise NotImplementedError('Only the methods GET, POST, PUT, DELETE are supported.')
 
         return r.json()


### PR DESCRIPTION
using `ValueError` does not seems appropriate since it has been associated with more primitive  _programming_ errors.
e.g.: `int("one")`will throw ValueError.
whereas `NotImplementedError` should be used when appropriate behavior is not supported , which exactly is the case.
