### PR TITLE
Change format of parameters for DELETE operation to JSON

### DIFF
--- a/keycdn/keycdn.py
+++ b/keycdn/keycdn.py
@@ -72,7 +72,7 @@ class Api(object):
         elif method == 'PUT':
             r = requests.put(url, auth=(self.__api_key, ''), data=params)
         elif method == 'DELETE':
-            r = requests.delete(url, auth=(self.__api_key, ''), data=params)
+            r = requests.delete(url, auth=(self.__api_key, ''), json=params)
         else:
             raise ValueError('Only the methods GET, POST, PUT, DELETE are supported.')
 


### PR DESCRIPTION
Current implementation of DELETE operations with parameters seems broken. KeyCDN API lists DELETE operations that either doesn't take additional parameters or take them in JSON format, while current implementation passes arguments as a dictionary. This patch fixes it.